### PR TITLE
Deregister a service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ consul_service_check_port: "{{ consul_service_port }}"
 consul_service_check_protocol: http
 consul_service_check_method: HEAD
 consul_service_check_target: http://localhost:{{ consul_service_check_port }}/
+consul_service_deregister: false
 
 # brianshumate.consul settings
 consul_group_name: all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,9 +34,17 @@
     group: bin
     mode: "0400"
   register: consul_service_definition
+  when: not consul_service_deregister
+
+- name: Remove Consul service
+  file:
+    path: "{{ consul_config_dir }}/{{ consul_service_name }}.service.json"
+    state: absent
+  register: consul_service_removal
+  when: consul_service_deregister
 
 - name: Reload Consul # noqa 503
   service:
     name: consul
     state: reloaded
-  when: consul_service_definition.changed
+  when: consul_service_definition.changed or consul_service_removal.changed


### PR DESCRIPTION
why:
Be able to unregister a consul service without recycling an instance