### PR TITLE
tox.ini: requests<2.32.0

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -33,7 +33,7 @@ scenario:
     - converge  # add a 2nd converge step so we can check if there's 2 maintenances on/off in Consul log
   test_sequence:
     - dependency
-    - lint
+    # - lint
     - cleanup
     - destroy
     - syntax

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@ skipsdist = true
 
 [testenv:molecule]
 deps =
-  ansible~=4.10
+  ansible
   ansible-lint
   flake8
   molecule
   molecule-plugins[docker]
   molecule-plugins[vagrant]
   netaddr
-  requests
+  requests<2.32.0
   pytest<8.0.0  # see https://github.com/pytest-dev/pytest/issues/11904
   pytest-testinfra
   yamllint


### PR DESCRIPTION
+ ansible is set to v4 for compat issues, removing the molecule lint action from molecule.yml