### PR TITLE
Add apt retries for molecule tests on debian<=12

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare
+  hosts: all
+  become: yes
+
+  tasks:
+  - name: Set apt retries for debian <=12
+    ansible.builtin.copy:
+      dest: /etc/apt/apt.conf.d/99-retries.conf
+      content: |
+        Acquire::Retries "5";
+      owner: root
+      group: root
+      mode: "0644"
+    become: true
+    when:
+      - ansible_distribution == "Debian"
+      - ansible_distribution_major_version | int <= 12


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a Molecule-only prepare step that writes an apt retry config on Debian 11/12 to reduce transient package install failures, without affecting non-Debian platforms or role logic.
> 
> **Overview**
> Adds a new Molecule `prepare` playbook that, on Debian <=12 test containers, writes `/etc/apt/apt.conf.d/99-retries.conf` to set `Acquire::Retries "5"`.
> 
> This makes Debian 11/12 Molecule runs more resilient to flaky apt downloads by applying the setting only during the scenario’s `prepare` phase.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d0a2c75c889ac764c49ba3ace82e612de64b0b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->