### PR TITLE
Fix service template when check_protocol is not http (missing endofline)

### DIFF
--- a/templates/consul_service.json.j2
+++ b/templates/consul_service.json.j2
@@ -19,8 +19,8 @@
             "id": "{{ consul_service_name }}",
             "name": "{{ consul_service_name }} {{ consul_service_check_protocol }} check on port {{ consul_service_check_port }}",
             "{{ consul_service_check_protocol }}": "{{ consul_service_check_target }}",
-            {%- if consul_service_check_protocol == "http" %}"method": "{{ consul_service_check_method }}",{% endif -%}
-            "interval": "10s",
+{% if consul_service_check_protocol == "http" %}            "method": "{{ consul_service_check_method }}",
+{% endif %}            "interval": "10s",
             "timeout": "{{ consul_service_check_timeout }}"
         }
         {%- endif %}


### PR DESCRIPTION
In case of non http check, the service template is missing a end of line breaking check definition.
This change will fix this by adding a newline in all cases.

:warning:  After more tests, I was wrong, this will not break consul at all. Consider it just as a cosmetic change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only formatting fix for Consul service registration JSON; no runtime logic changes beyond correct output for non-http checks.
> 
> **Overview**
> Fixes **invalid Consul service JSON** when `consul_service_check_protocol` is not `http` (e.g. TCP checks).
> 
> The Jinja whitespace around the optional `"method"` field was collapsing the newline before `"interval"`, so the rendered check block could break JSON parsing. The template now emits an explicit line break after the protocol/target line in all cases, and only adds `"method"` when the protocol is `http`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcead0a9f94a7277ab3e88ee08fe2fcb4f000fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->