### PR TITLE
Use our public systemd-debian image in molecule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,13 +27,8 @@ pipeline {
           }
           steps {
             script { checkout scm }
-            withCredentials([
-                [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'AWS Jenkins community'],
-            ]) {
-              sh "aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 119948825560.dkr.ecr.eu-west-1.amazonaws.com"
-              sh 'tox -e molecule-ansible8'
-              sh 'tox -e molecule-ansible8-debian12'
-            }
+            sh 'tox -e molecule-ansible8'
+            sh 'tox -e molecule-ansible8-debian12'
           }
           post {
             always {
@@ -48,12 +43,7 @@ pipeline {
           }
           steps {
             script { checkout scm }
-            withCredentials([
-                [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'AWS Jenkins community'],
-            ]) {
-              sh "aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 119948825560.dkr.ecr.eu-west-1.amazonaws.com"
-              sh 'tox -e molecule-ansible13'
-            }
+            sh 'tox -e molecule-ansible13'
           }
           post {
             always {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ python environment and start testing.
 
 Python & [tox](https://tox.readthedocs.io). See imports in `library/*` and tasks in `molecule/default/converge.yml` if any specific, but those should be added in `tox.ini`.
 
+The molecule tests use the public
+[`wazoplatform/systemd-debian`](https://hub.docker.com/r/wazoplatform/systemd-debian)
+image (tags `11`, `12`, `13`)
+
 ## Role Variables
 
 See [defaults/main.yml](defaults/main.yml).

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
   name: docker
 platforms:
   - name: molecule-consul-service-debian${MOLECULE_DEBIAN_VERSION:-11}
-    image: 119948825560.dkr.ecr.eu-west-1.amazonaws.com/wazo-it-tools/debian-systemd:${MOLECULE_DEBIAN_VERSION:-11}
+    image: wazoplatform/systemd-debian:${MOLECULE_DEBIAN_VERSION:-11}
     privileged: True
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and test-container sourcing only; no application or Consul role runtime behavior changes, with the main caveat that CI depends on Docker Hub availability instead of ECR.
> 
> **Overview**
> **Molecule** now uses the public **`wazoplatform/systemd-debian`** image (tags `11`/`12`/`13` via `MOLECULE_DEBIAN_VERSION`) instead of the private ECR **`wazo-it-tools/debian-systemd`** image.
> 
> **Jenkins** parallel test stages no longer wrap tox in **`withCredentials`** for AWS or run **`aws ecr get-login-password`** / **`docker login`** before molecule; they only invoke the existing tox molecule envs.
> 
> **README** documents the public image requirement for local and CI molecule runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f87141789a6aaf7983268e0aec654a786dfe9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->